### PR TITLE
Allow usage with any architecture

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library to debounce button switches, detect presses, releases, 
 paragraph=The Button library is for debouncing and reading momentary contact switches like tactile button switches. "Long presses" of arbitrary length can be detected. Works well in state machine constructs. Use the read() function to read each button in the main loop, which should execute as fast as possible.
 category=Signal Input/Output
 url=https://github.com/JChristensen/JC_Button
-architectures=avr
+architectures=*


### PR DESCRIPTION
Because no assembly-level code is used, this removes warnings when used with ARM or (in my case) ESP8266 chips.