### PR TITLE
Allow to use external i/o on read(), optimizes button bulk processing

### DIFF
--- a/src/JC_Button.cpp
+++ b/src/JC_Button.cpp
@@ -25,7 +25,11 @@ void Button::begin()
 /-----------------------------------------------------------------------*/
 bool Button::read()
 {
-    return Button::read(millis());
+    return Button::read(millis(), digitalRead(m_pin));
+}
+bool Button::read(bool pinVal)
+{
+    return Button::read(millis(), pinVal);
 }
 bool Button::read(uint32_t ms)
 {

--- a/src/JC_Button.cpp
+++ b/src/JC_Button.cpp
@@ -25,8 +25,14 @@ void Button::begin()
 /-----------------------------------------------------------------------*/
 bool Button::read()
 {
-    uint32_t ms = millis();
-    bool pinVal = digitalRead(m_pin);
+    return Button::read(millis());
+}
+bool Button::read(uint32_t ms)
+{
+    return Button::read(ms, digitalRead(m_pin));
+}
+bool Button::read(uint32_t ms, bool pinVal)
+{
     if (m_invert) pinVal = !pinVal;
     if (ms - m_lastChange < m_dbTime)
     {

--- a/src/JC_Button.h
+++ b/src/JC_Button.h
@@ -30,6 +30,8 @@ class Button
         // false for released. Call this function frequently to ensure
         // the sketch is responsive to user input.
         bool read();
+        bool read(uint32_t ms);
+        bool read(uint32_t ms, bool pinVal);
 
         // Returns true if the button state was pressed at the last call to read().
         // Does not cause the button to be read.

--- a/src/JC_Button.h
+++ b/src/JC_Button.h
@@ -30,6 +30,7 @@ class Button
         // false for released. Call this function frequently to ensure
         // the sketch is responsive to user input.
         bool read();
+        bool read(bool pinVal);
         bool read(uint32_t ms);
         bool read(uint32_t ms, bool pinVal);
 
@@ -78,7 +79,7 @@ class Button
 class ToggleButton : public Button
 {
     public:
-    
+
         // constructor is similar to Button, but includes the initial state for the toggle.
         ToggleButton(uint8_t pin, bool initialState=false, uint32_t dbTime=25, uint8_t puEnable=true, uint8_t invert=true)
             : Button(pin, dbTime, puEnable, invert), m_toggleState(initialState) {}


### PR DESCRIPTION
This modification allows to use direct io-pin read and single `millis()` call for several buttons at once. That allows to save up some cycles for speed-critical applications.

```
uint32_t ms = millis();
button1.read(ms, PINB & (1 << PINB1));
button2.read(ms, PINB & (1 << PINB2));
button3.read(ms, PINB & (1 << PINB3));
button4.read(ms, PINB & (1 << PINB4));
button5.read(ms, PINB & (1 << PINB5));
```