### PR TITLE
MCP23017 I/O extender functionality

### DIFF
--- a/src/JC_Button.cpp
+++ b/src/JC_Button.cpp
@@ -2,6 +2,7 @@
 // https://github.com/JChristensen/JC_Button
 // Copyright (C) 2018 by Jack Christensen and licensed under
 // GNU GPL v3.0, https://www.gnu.org/licenses/gpl.html
+// Modified by Dennis Loyer to work with MCP23017 I/O extender
 
 #include "JC_Button.h"
 
@@ -10,13 +11,39 @@
 /-----------------------------------------------------------------------*/
 void Button::begin()
 {
-    pinMode(m_pin, m_puEnable ? INPUT_PULLUP : INPUT);
-    m_state = digitalRead(m_pin);
-    if (m_invert) m_state = !m_state;
-    m_time = millis();
-    m_lastState = m_state;
-    m_changed = false;
-    m_lastChange = m_time;
+	
+	
+	if ((bool)m_mcp)
+	{
+		
+		if (m_puEnable)
+		{
+			m_mcp->pinMode(m_pin, INPUT);
+			m_mcp->pullUp(m_pin, HIGH);
+		}
+		else
+		{
+			m_mcp->pinMode(m_pin, INPUT);
+			m_mcp->pullUp(m_pin, LOW);
+		}
+		m_state = m_mcp->digitalRead(m_pin);
+		if (m_invert) m_state = !m_state;
+		m_time = millis();
+		m_lastState = m_state;
+		m_changed = false;
+		m_lastChange = m_time;
+	
+	}
+	else{
+		pinMode(m_pin, m_puEnable ? INPUT_PULLUP : INPUT);
+		m_state = digitalRead(m_pin);
+		if (m_invert) m_state = !m_state;
+		m_time = millis();
+		m_lastState = m_state;
+		m_changed = false;
+		m_lastChange = m_time;
+	}
+	
 }
 
 /*----------------------------------------------------------------------*
@@ -25,22 +52,49 @@ void Button::begin()
 /-----------------------------------------------------------------------*/
 bool Button::read()
 {
-    uint32_t ms = millis();
-    bool pinVal = digitalRead(m_pin);
-    if (m_invert) pinVal = !pinVal;
-    if (ms - m_lastChange < m_dbTime)
-    {
-        m_changed = false;
-    }
-    else
-    {
-        m_lastState = m_state;
-        m_state = pinVal;
-        m_changed = (m_state != m_lastState);
-        if (m_changed) m_lastChange = ms;
-    }
-    m_time = ms;
-    return m_state;
+	
+	if((bool)m_mcp)
+	{
+		
+		uint32_t ms = millis();
+		bool pinVal = m_mcp->digitalRead(m_pin);
+		if (m_invert) pinVal = !pinVal;
+		if (ms - m_lastChange < m_dbTime)
+		{
+			m_changed = false;
+		}
+		else
+		{
+			m_lastState = m_state;
+			m_state = pinVal;
+			m_changed = (m_state != m_lastState);
+			if (m_changed) m_lastChange = ms;
+		}
+		m_time = ms;
+		return m_state;
+		
+	}
+	else
+	{
+		uint32_t ms = millis();
+		bool pinVal = digitalRead(m_pin);
+		if (m_invert) pinVal = !pinVal;
+		if (ms - m_lastChange < m_dbTime)
+		{
+			m_changed = false;
+		}
+		else
+		{
+			m_lastState = m_state;
+			m_state = pinVal;
+			m_changed = (m_state != m_lastState);
+			if (m_changed) m_lastChange = ms;
+		}
+		m_time = ms;
+		return m_state;
+	}
+	
+	
 }
 
 /*----------------------------------------------------------------------*

--- a/src/JC_Button.h
+++ b/src/JC_Button.h
@@ -8,7 +8,6 @@
 #define JC_BUTTON_H_INCLUDED
 
 #include <Arduino.h>
-#include <Adafruit_mcp23017.h>
 
 class Button
 {

--- a/src/JC_Button.h
+++ b/src/JC_Button.h
@@ -2,6 +2,7 @@
 // https://github.com/JChristensen/JC_Button
 // Copyright (C) 2018 by Jack Christensen and licensed under
 // GNU GPL v3.0, https://www.gnu.org/licenses/gpl.html
+// Modified by Dennis Loyer to work with MCP23017 I/O extender
 
 #ifndef JC_BUTTON_H_INCLUDED
 #define JC_BUTTON_H_INCLUDED

--- a/src/JC_Button.h
+++ b/src/JC_Button.h
@@ -7,6 +7,7 @@
 #define JC_BUTTON_H_INCLUDED
 
 #include <Arduino.h>
+#include <Adafruit_mcp23017.h>
 
 class Button
 {
@@ -20,8 +21,14 @@ class Button
         // dbTime   Debounce time in milliseconds (default 25ms)
         // puEnable true to enable the AVR internal pullup resistor (default true)
         // invert   true to interpret a low logic level as pressed (default true)
+        // For overloaded constructor:
+        // mcp      the address of the I/O extender on which the pin resides. You must use the address_of
+        //          operator when passing name of the I/O extender. I.E. &name
         Button(uint8_t pin, uint32_t dbTime=25, uint8_t puEnable=true, uint8_t invert=true)
             : m_pin(pin), m_dbTime(dbTime), m_puEnable(puEnable), m_invert(invert) {}
+    
+        Button(int mcp, uint8_t pin, uint32_t dbTime=25, uint8_t puEnable=true, uint8_t invert=true)
+            : m_mcp(mcp), m_pin(pin), m_dbTime(dbTime), m_puEnable(puEnable), m_invert(invert) {}
 
         // Initialize a Button object and the pin it's connected to
         void begin();
@@ -69,6 +76,7 @@ class Button
         bool m_changed;         // state changed since last read
         uint32_t m_time;        // time of current state (ms from millis)
         uint32_t m_lastChange;  // time of last state change (ms)
+        Adafruit_MCP23017* m_mcp; 				// address of Adafruit_mcp23017 object
 };
 
 // a derived class for a "push-on, push-off" (toggle) type button.
@@ -80,6 +88,9 @@ class ToggleButton : public Button
         // constructor is similar to Button, but includes the initial state for the toggle.
         ToggleButton(uint8_t pin, bool initialState=false, uint32_t dbTime=25, uint8_t puEnable=true, uint8_t invert=true)
             : Button(pin, dbTime, puEnable, invert), m_toggleState(initialState) {}
+            
+        ToggleButton(int mcp, uint8_t pin, bool initialState=false, uint32_t dbTime=25, uint8_t puEnable=true, uint8_t invert=true)
+            : Button(mcp, pin, dbTime, puEnable, invert), m_toggleState(initialState) {}
 
         // read the button and return its state.
         // should be called frequently.


### PR DESCRIPTION
I've updated your library to allow it to play well with the Adafruit_MCP23017 library so that the number of buttons you can have isn't limited to the standard number of I/O pins.

