### PR TITLE
Added Multiple Quick Press Detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Arduino Button Library
 https://github.com/JChristensen/JC_Button  
+https://github.com/Kuantronic/JC_Button   
 README file  
 
 ## License
@@ -12,6 +13,10 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/gpl.html>
 
 ## Introduction
+This is a modified version of Jack Christensen's JC_Button library by Kuantronic. It adds the functionality to detect mutliple presses on a single button. The Arduino can do certain tasks based on the amount of time that button is pressed quickly.
+
+The rest of the README contains the original content plus the info needed to use the muli-press functionality.
+
 The Button library is for debouncing and reading momentary contact switches like tactile button switches.  "Long presses" of arbitrary length can be detected. Works well in state machine constructs.  Use the read() function to read each button in the main loop, which should execute as fast as possible.
 
 The simplest way to use a button with an AVR microcontroller is to wire the button between a GPIO pin and ground, and turn on the AVR internal pullup resistor. The Button class constructor takes four arguments, but three have default values that work for a button wired in this manner.
@@ -189,27 +194,50 @@ The time in milliseconds when the button last changed state *(unsigned long)*
 unsigned long msLastChange = myButton.lastChange();
 ```
 
-## ToggleButton Library Functions
-
-### changed()
+### multiPressRead()
 ##### Description
-Returns a boolean value (true or false) to indicate whether the toggle button changed state the last time `read()` was called.
+Reads the button to detect when it's pressed and released in fast successions. Think of the audio control in Apple's wired EarPods headphones. It detects single press to resume/pause, double press to skip forward, and triple press to skip backward. 
+Like the read() function, this needs to be called as frequently as possible to be working and/or effective.
+Can count up to 255 presses but up to 4 quick presses should be more than enough for 99.99% of the use cases.
 ##### Syntax
-`myToggle.changed();`
+`myBtn.multiPressRead();`
 ##### Parameters
 None.
 ##### Returns
-*true* if the toggle state changed, else *false* *(bool)*
+The amount of time it was pressed in fast succession in *uint8_t*. It only returns a value other than 0 after the wait time for the next successive button press/release expires.
 ##### Example
 ```c++
-if (myToggle.changed())
-{
-    // do something
-}
-else
-{
-    // do something different
-}
+ uint8_t numOfPresses = myBtn.multiPressRead();
+ switch (numOfPresses){
+    case 1:
+      //single press
+      break;
+    case 2:
+      //double press
+      break;
+    case 3:
+      //triple press
+      break;
+    case 4:
+      //quadruple press
+    default:
+      //zero press, still waiting for more presses, or past quadruple press
+      break;
+  }
+```
+
+### setMultiPressTimer()
+##### Description
+Sets the time the button will wait for the next press to be counted as a fast successive press. Default time is 200 ms.
+##### Syntax
+`myBtn.setMultiPressTimer(ms);`
+##### Parameters
+**ms:** Time in milliseconds *(unsigned long)*
+##### Returns
+None.
+##### Example
+```c++
+myBtn.setMultiPressTimer(250);
 ```
 
 ### toggleState()

--- a/examples/MultiPressRead/MultiPressRead.ino
+++ b/examples/MultiPressRead/MultiPressRead.ino
@@ -1,0 +1,48 @@
+// Arduino Button Library
+// https://github.com/JChristensen/JC_Button
+// Copyright (C) 2018 by Jack Christensen and licensed under
+// GNU GPL v3.0, https://www.gnu.org/licenses/gpl.html
+//
+// Example of the multiPressRead() functionality added by Kuan Liu
+// returns the number of presses in fast succession
+
+#include <JC_Button.h>          // https://github.com/Kuantronic/JC_Button
+
+// button pin assignment
+#define BUTTON_PIN 7              // connect a button switch from this pin to ground
+
+Button myBtn(BUTTON_PIN);       // define the button
+
+void setup(){
+  Serial.begin(115200);           //initalize serial at 115200 baud rate
+  myBtn.begin();                  //initialize the button object
+
+  //uncomment the line below to set the time allowed between presses.
+  //myBtn.setMultiPressTimer(150);  // default time is 200ms if this function is not called.
+  
+  //the shorter the time, the more responsive it becomes to returning the number of counts
+  //BUT if it gets too short, it becomes more likely the fast presses will NOT count towards the succession
+}
+
+void loop(){
+  uint8_t numOfPresses = myBtn.multiPressRead();
+
+  switch (numOfPresses){
+    case 1:
+      Serial.println("single press!");
+      break;
+    case 2:
+      Serial.println("double press!");
+      break;
+    case 3:
+      Serial.println("triple press!");
+      break;
+    case 4:
+      Serial.println("quadruple press!");
+    default:
+      // do nothing
+      // for no press and presses over 4 in fast succession
+      break;
+  }
+
+}

--- a/src/JC_Button.cpp
+++ b/src/JC_Button.cpp
@@ -17,6 +17,9 @@ void Button::begin()
     m_lastState = m_state;
     m_changed = false;
     m_lastChange = m_time;
+
+    m_pressCount = 0;
+    pressRead = false;
 }
 
 /*----------------------------------------------------------------------*
@@ -41,6 +44,53 @@ bool Button::read()
     }
     m_time = ms;
     return m_state;
+}
+
+/*----------------------------------------------------------------------*
+ * multiPressRead() checks the time between changes in the m_state      *
+ * If it changes quick enough, it'll detect it as a multi presses       *
+ * If a set time passes without another press, it'll return the times   *
+ * it got multi-pressed
+ *----------------------------------------------------------------------*/
+uint8_t Button::multiPressRead() {
+
+    if (read()) {
+        //makes sure it counts the press ONLY once
+        if (!m_pressRead) {
+            m_pressCount++;
+            m_pressRead = true;
+        }
+        return checkMultiPress();
+    }
+
+    if (!read()) {
+        m_pressRead = false;
+        return checkMultiPress();
+    }
+}
+
+/*----------------------------------------------------------------------*
+ * Checks the time that passed without another press. If it exceeds the *
+ * limit, it returns the amount of fast presses it counted.             *
+ *----------------------------------------------------------------------*/
+uint8_t Button::checkMultiPress() {
+
+    if (millis() - m_lastChange > m_multiPressTimeLimit) {
+        uint8_t numberOfPresses = m_pressCount;
+        m_pressCount = 0;
+        return numberOfPresses;
+    }
+    else {
+        return 0;
+    }
+}
+
+/*----------------------------------------------------------------------*
+ * Sets the time in ms for the next button press to be counted as       *
+ * a successive multi press.                                            *
+ *----------------------------------------------------------------------*/
+void Button::setMultiPressTimer(uint32_t multiPressTimeLimit) {
+    m_multiPressTimeLimit = multiPressTimeLimit;
 }
 
 /*----------------------------------------------------------------------*

--- a/src/JC_Button.cpp
+++ b/src/JC_Button.cpp
@@ -19,7 +19,7 @@ void Button::begin()
     m_lastChange = m_time;
 
     m_pressCount = 0;
-    pressRead = false;
+    m_pressRead = false;
 }
 
 /*----------------------------------------------------------------------*

--- a/src/JC_Button.cpp
+++ b/src/JC_Button.cpp
@@ -29,8 +29,6 @@ void Button::begin()
 bool Button::read()
 {
     uint32_t ms = millis();
-    bool pinVal = digitalRead(m_pin);
-    if (m_invert) pinVal = !pinVal;
     if (ms - m_lastChange < m_dbTime)
     {
         m_changed = false;
@@ -38,7 +36,8 @@ bool Button::read()
     else
     {
         m_lastState = m_state;
-        m_state = pinVal;
+        m_state = digitalRead(m_pin);
+        if (m_invert) m_state = !m_state;
         m_changed = (m_state != m_lastState);
         if (m_changed) m_lastChange = ms;
     }

--- a/src/JC_Button.h
+++ b/src/JC_Button.h
@@ -59,6 +59,13 @@ class Button
         // changed state.
         uint32_t lastChange();
 
+        // returns the number of presses done in rapid succession
+        uint8_t multiPressRead();
+
+        // overrides the time in ms it allows the next press to arrive to
+        // count as a multi-press
+        void setMultiPressTimer(uint32_t multiPressTimeLimit);
+
     private:
         uint8_t m_pin;          // arduino pin number connected to button
         uint32_t m_dbTime;      // debounce time (ms)
@@ -69,6 +76,14 @@ class Button
         bool m_changed;         // state changed since last read
         uint32_t m_time;        // time of current state (ms from millis)
         uint32_t m_lastChange;  // time of last state change (ms)
+        
+        uint8_t  m_pressCount;  // count the times button is pressed in rapid succession
+        bool m_pressRead;       // bool status to make sure m_pressCount only increment once with one button press
+        uint32_t m_multiPressTimeLimit = 200; //time in ms it allows for next press to arrive to count as a multi-press
+
+        //checks if the next press arrives
+        //in the allowed time limit or not
+        uint8_t checkMultiPress();
 };
 
 // a derived class for a "push-on, push-off" (toggle) type button.


### PR DESCRIPTION
Added the multiPressRead() function to the library. It checks the time between different presses on the same button. If the press is quick enough, it counts as a successive multi-press. Think of the audio control in Apple's wired EarPods headphones. It detects single press to resume/pause, double press to skip forward, and triple press to skip backward.

Updated the README file and added an example ino file to showcase this new feature.

Have tested the code myself and found no bug or error as of yet.